### PR TITLE
now deep-copies headers when making a copy of a request object

### DIFF
--- a/slogging/internal_proxy.py
+++ b/slogging/internal_proxy.py
@@ -55,10 +55,10 @@ def make_request_body_file(source_file, compress=True):
 
 def webob_request_copy(orig_req, source_file=None, compress=True):
     req_copy = orig_req.copy()
+    req_copy.headers = dict(orig_req.headers)
     if source_file:
         req_copy.body_file = make_request_body_file(source_file,
                                                     compress=compress)
-    req_copy.content_length = orig_req.content_length
     return req_copy
 
 

--- a/test_slogging/unit/test_internal_proxy.py
+++ b/test_slogging/unit/test_internal_proxy.py
@@ -78,6 +78,8 @@ class TestInternalProxy(unittest.TestCase):
         self.assertEquals(req.path, req2.path)
         self.assertEquals(req.path_info, req2.path_info)
         self.assertFalse(req is req2)
+        self.assertEquals(req.headers, req2.headers)
+        self.assertFalse(req.headers is req2.headers)
 
     def test_handle_request(self):
         status_codes = [200]


### PR DESCRIPTION
Headers were copied with only a shallow copy, therefore messing up things like content-length (since modifying the copied object would affect the original object). Making a deep copy of the headers fixes this.
