### PR TITLE
fixed error in checking for metadata key

### DIFF
--- a/slogging/access_log_delivery.py
+++ b/slogging/access_log_delivery.py
@@ -155,7 +155,7 @@ class AccessLogDelivery(LogProcessorCommon):
         if flag is None:
             metadata = self.internal_proxy.get_container_metadata(account,
                                                                   container)
-            val = metadata.get(self.metadata_key)
+            val = metadata.get(self.metadata_key, '')
             flag = val.lower() in TRUE_VALUES
             self.memcache.set(key, flag, timeout=self.frequency)
         return flag

--- a/test_slogging/unit/test_access_log_delivery.py
+++ b/test_slogging/unit/test_access_log_delivery.py
@@ -174,7 +174,7 @@ class TestAccessLogDelivery(unittest.TestCase):
         self.assertEquals(res, expected)
         p.internal_proxy.get_container_metadata = my_get_metadata_true_upper
         p.memcache = FakeMemcache()
-        res = p.get_container_save_log_flag('a', 'c2')
+        res = p.get_container_save_log_flag('a', 'c3')
         expected = True
         self.assertEquals(res, expected)
 


### PR DESCRIPTION
turns out that casting None to .lower() doesn't work
