### PR TITLE
Enabling the use of CIDR inside configuration files

### DIFF
--- a/slogging/access_processor.py
+++ b/slogging/access_processor.py
@@ -17,6 +17,8 @@ import collections
 from urllib import unquote
 import copy
 
+from iptools import IpRangeList
+
 from swift.common.utils import split_path, get_logger
 
 month_map = '_ Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec'.split()
@@ -31,9 +33,9 @@ class AccessLogProcessor(object):
         self.server_name = conf.get('server_name', 'proxy-server')
         for conf_tag in ['lb_private_ips', 'service_ips',
                          'service_log_sources']:
-            setattr(self, conf_tag,
+            setattr(self, conf_tag, IpRangeList(*
                 [x.strip() for x in conf.get(conf_tag, '').split(',') \
-                 if x.strip()])
+                 if x.strip()]))
         self.warn_percent = float(conf.get('warn_percent', '0.8'))
         self.logger = get_logger(conf, log_route='access-processor')
 

--- a/test_slogging/unit/test_access_processor.py
+++ b/test_slogging/unit/test_access_processor.py
@@ -21,6 +21,12 @@ from slogging import access_processor
 
 class TestAccessProcessor(unittest.TestCase):
 
+    def test_CIDR_works(self):
+        p = access_processor.AccessLogProcessor({'lb_private_ips': '127.0.0.1,192.168/16,10/24' })
+        self.assertTrue('192.168.2.3' in p.lb_private_ips)
+        self.assertTrue('127.0.0.1' in p.lb_private_ips)
+        self.assertFalse('192.167.2.3' in p.lb_private_ips)
+
     def test_log_line_parser_query_args(self):
         p = access_processor.AccessLogProcessor({})
         log_line = [str(x) for x in range(18)]


### PR DESCRIPTION
this applies only to lb_private_ips, service_ips and service_log_sources inside the config. Uses the iptools that is 3rd party but pip installable. 
