### PR TITLE
Update tox.ini for swift after Havana

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,8 @@ setenv = VIRTUAL_ENV={envdir}
          NOSE_OPENSTACK_STDOUT=1
 deps =
   {toxinidir}/../swift
-  -r{toxinidir}/../swift/tools/pip-requires
-  -r{toxinidir}/../swift/tools/test-requires
+  -r{toxinidir}/../swift/requirements.txt
+  -r{toxinidir}/../swift/test-requirements.txt
   -r{toxinidir}/tools/pip-requires
 commands = nosetests {posargs}
 


### PR DESCRIPTION
The two files "tools/pip-requires" and "tools/test-requires" written in tox.ini
are not in swift after Havana. In swift after Havana, "requirements.txt" and
"test-requirements.txt" are successors of them. This patch fixes these file names.