### PR TITLE
Add install requirement of tzlocal to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Environment :: No Input/Output (Daemon)',
         ],
-    install_requires=[],  # removed for better compat
+    install_requires=['tzlocal'],  # There should be few required modules for better compat
     scripts=['bin/swift-account-stats-logger',
              'bin/swift-container-stats-logger',
              'bin/swift-log-stats-collector', 'bin/swift-log-uploader',


### PR DESCRIPTION
In commit "c3312216a254bb49e4548bf1c27b344588c4f108",
some programs are changed to use tzlocal module.
However, setup.py doesn't have requirement of tzlocal information.
This patch adds install requirement of tzlocal to setup.py
